### PR TITLE
Fix municipality name lookup from GeoJSON

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,6 +158,7 @@ def build_geojson_lookup(geojson: dict, key: str) -> dict[int, str]:
 
         name = (
             properties.get("Município")
+            or properties.get("Municipio")
             or properties.get("NM_MUN")
             or properties.get("NM_MUNICIP")
             or properties.get("NOME_MUNI")


### PR DESCRIPTION
## Summary
- ensure the GeoJSON lookup also reads the `Municipio` property so municipalities without accent marks retain their names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68efe0bfe970832aa7f486d6b57c55fc