### PR TITLE
Fix municipality name lookup from GeoJSON

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,6 +158,7 @@ def build_geojson_lookup(geojson: dict, key: str) -> dict[int, str]:
 
         name = (
             properties.get("Município")
+            or properties.get("Municipio")
             or properties.get("NM_MUN")
             or properties.get("NM_MUNICIP")
             or properties.get("NOME_MUNI")
@@ -277,8 +278,11 @@ for col in ["Município", "Região", "STATUS", "Pavimento"]:
 
 if "STATUS" in df.columns:
     df["STATUS"] = df["STATUS"].str.title()
-    extra_status = sorted(set(df["STATUS"].dropna()) - set(STATUS_ORDER))
-    status_categories = STATUS_ORDER + [status for status in extra_status if status not in STATUS_ORDER]
+    status_values = df["STATUS"].dropna()
+    unique_status = list(dict.fromkeys(status_values))
+    ordered_defaults = [status for status in STATUS_ORDER if status in unique_status]
+    extra_status = [status for status in unique_status if status not in ordered_defaults]
+    status_categories = ordered_defaults + extra_status
     df["STATUS"] = pd.Categorical(df["STATUS"], categories=status_categories, ordered=True)
 
 if "Região" in df.columns:


### PR DESCRIPTION
## Summary
- ensure the GeoJSON lookup also reads the `Municipio` property so municipalities without accent marks retain their names
- restrict RTV status categories to only those present in the dataset so unused statuses are not displayed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68efe0bfe970832aa7f486d6b57c55fc